### PR TITLE
DATASHARE-68: Migrate Links

### DIFF
--- a/config/navigation.json
+++ b/config/navigation.json
@@ -52,7 +52,7 @@
       },
       {
         "name": "NIH Data Sharing Guidance",
-        "link": "https://sharing.nih.gov",
+        "link": "https://grants.nih.gov/policy-and-compliance/policy-topics/sharing-policies",
         "className": "navMobileSubItem"
       },
       {

--- a/pages/Guidance/genomic-data-sharing.md
+++ b/pages/Guidance/genomic-data-sharing.md
@@ -14,7 +14,7 @@ Investigators submitting their genomic research data to an NIH or NCI repository
 
 The GDS Policy applies to all NCI-funded research that generates large-scale human or non-human genomic data, as well as the use of these data for subsequent research. NCI may choose to apply the GDS Policy to projects generating smaller scale genomic data depending on the state of the science, the needs of the research community, and programmatic priorities. Investigators should consult with corresponding NCI Program Officers or Intramural Scientific Directors as early as possible in the genomic research planning process.
 
-## General Guidelines for Large-Scale Research Projects
+## Thresholds for Large-Scale Genomics Research Projects
 
 Regardless of study design, NCI requires sharing of large-scale genomics research data. This includes, but is not limited to, the following:
 
@@ -54,11 +54,11 @@ Research that does not meet the above criteria and involves instrument calibrati
 
 | | |
 |---|---|
-| ![DNA file icon](https://raw.githubusercontent.com/CBIIT/ccdi-ods-content/main/pages/images/icons/dna_file_icon.png) | [Genomic Data Sharing Policy](https://sharing.nih.gov/genomic-data-sharing-policy/about-genomic-data-sharing/gds-policy-overview) |
-| ![Folder icon](https://raw.githubusercontent.com/CBIIT/ccdi-ods-content/main/pages/images/icons/folder_icon.png) | [Institutional Certifications](https://sharing.nih.gov/genomic-data-sharing-policy/institutional-certifications/about-institutional-certifications)** |
-| ![Gear with checkmark icon](https://raw.githubusercontent.com/CBIIT/ccdi-ods-content/main/pages/images/icons/gear_checkmark_icon.png) | [Harmonization of Sharing Plans](https://sharing.nih.gov/genomic-data-sharing-policy/developing-genomic-data-sharing-plans#after) |
-| ![Data cloud icon](https://raw.githubusercontent.com/CBIIT/ccdi-ods-content/main/pages/images/icons/cloud_upload_icon.png) | [Where to Submit Genomic Data](https://sharing.nih.gov/genomic-data-sharing-policy/submitting-genomic-data/where-to-submit-genomic-data)<br> Follow step-by-step instructions for submitting genomic data sets to dbGaP based on funding category:<br>- [Intramural and Extramural NCI Investigators](https://sharing.nih.gov/genomic-data-sharing-policy/submitting-genomic-data/how-to-register-and-submit-a-study-in-dbgap) <br> - [Non-NCI Funded Studies](/post/Process/non-NIH-funded-study-submission) |
-| ![Person icon](https://raw.githubusercontent.com/CBIIT/ccdi-ods-content/main/pages/images/icons/person_icon.png) | [Contact](https://sharing.nih.gov/genomic-data-sharing-policy/resources/contacts-and-help#gds_support) <br> Find the appropriate Genomic Program Administrator to work with throughout the submission process. |
+| ![DNA file icon](https://raw.githubusercontent.com/CBIIT/ccdi-ods-content/main/pages/images/icons/dna_file_icon.png) | [Genomic Data Sharing Policy](https://grants.nih.gov/policy-and-compliance/policy-topics/sharing-policies/gds/overview) |
+| ![Folder icon](https://raw.githubusercontent.com/CBIIT/ccdi-ods-content/main/pages/images/icons/folder_icon.png) | [Institutional Certifications](https://grants.nih.gov/policy-and-compliance/policy-topics/sharing-policies/gds/institutional-certifications)** |
+| ![Gear with checkmark icon](https://raw.githubusercontent.com/CBIIT/ccdi-ods-content/main/pages/images/icons/gear_checkmark_icon.png) | [Harmonization of Sharing Plans](https://grants.nih.gov/policy-and-compliance/policy-topics/sharing-policies/gds/developing-genomic-data-sharing-plans) |
+| ![Data cloud icon](https://raw.githubusercontent.com/CBIIT/ccdi-ods-content/main/pages/images/icons/cloud_upload_icon.png) | [Where to Submit Genomic Data](https://grants.nih.gov/policy-and-compliance/policy-topics/sharing-policies/gds/where-to-submit)<br> Follow step-by-step instructions for submitting genomic data sets to dbGaP based on funding category:<br>- [Intramural and Extramural NCI Investigators](https://grants.nih.gov/policy-and-compliance/policy-topics/sharing-policies/gds/register-submit-study-dbgap) <br> - [Non-NCI Funded Studies](/post/Process/non-NIH-funded-study-submission) |
+| ![Person icon](https://raw.githubusercontent.com/CBIIT/ccdi-ods-content/main/pages/images/icons/person_icon.png) | [Contact](https://grants.nih.gov/policy-and-compliance/policy-topics/sharing-policies/gds/gds-ic-contacts#gds_support) <br> Find the appropriate Genomic Program Administrator to work with throughout the submission process. |
 
 **Please note that General Research Use without any further restricting modifiers allows the maximal benefit of research funded with public dollars and is preferred whenever possible and consistent with informed consent. If disease-specific data use or data-use modifiers are required, please contact the [NCI Office of Data Sharing](mailto:NCIOfficeofDataSharing@mail.nih.gov) for further guidance.
 
@@ -73,7 +73,7 @@ Research that does not meet the above criteria and involves instrument calibrati
   - If no, proceed to Question 2.
   - If yes, proceed to Question 3.
 
-- Question 2: Are you generating or collecting [scientific data](https://grants.nih.gov/grants/guide/notice-files/NOT-OD-21-013.html) (non-genomic) for your proposed project(s)?
+- Question 2: Are you generating or collecting [scientific data](https://grants.nih.gov/policy-and-compliance/policy-topics/sharing-policies/dms/policy-overview) (non-genomic) for your proposed project(s)?
   - If no, your projects do not generate scientific data. Neither the DMS nor the GDS Policy apply.
   - If yes, Follow the DMS Policy expectations as defined by your NOFOs/ICO policy/program. The GDS Policy does not apply.
 
@@ -81,19 +81,19 @@ Research that does not meet the above criteria and involves instrument calibrati
   - If no, proceed to Question 4.
   - If yes, proceed to Question 5.
 
-- Question 4: Does the data meet [NCI thresholds](https://datascience.cancer.gov/data-sharing/genomic-data-sharing/about-the-genomic-data-sharing-policy) for genomic data sharing for non-human specimens?
+- Question 4: Does the data meet [NCI thresholds](#thresholds-for-large-scale-genomics-research-projects) for genomic data sharing for non-human specimens?
   - If no, follow the DMS Policy expectations as defined by your NOFOs/ICO policy/program.
-  - If yes, follow the [GDS Policy expectations](https://sharing.nih.gov/genomic-data-sharing-policy/submitting-genomic-data/data-submission-and-release-expectations):
+  - If yes, follow the [GDS Policy expectations](https://grants.nih.gov/policy-and-compliance/policy-topics/sharing-policies/gds/data-submission-and-release-expectations):
     - No Institutional Certification is required.
     - Full sequence data is not required.
     - Your data do not have to be submitted to NIH/NCI-supported repositories (e.g., dbGaP).
 
-- Question 5: Does the data meet [NCI thresholds](https://datascience.cancer.gov/data-sharing/genomic-data-sharing/about-the-genomic-data-sharing-policy) for either genomic data sharing or rare-cancers/program priorities?
+- Question 5: Does the data meet [NCI thresholds](#thresholds-for-large-scale-genomics-research-projects) for either genomic data sharing or rare-cancers/program priorities?
   - If no, follow DMS Policy expectations* as defined by your NOFOs/ICO policy/program.
   - If yes, follow the GDS Policy expectations:
-    - [Provide your Institutional Certification by Just In Time](https://sharing.nih.gov/genomic-data-sharing-policy/institutional-certifications/completing-an-institutional-certification-form).
-    - [Submit your data to NIH-supported repositories](https://sharing.nih.gov/genomic-data-sharing-policy/submitting-genomic-data/where-to-submit-genomic-data).
-    - [Observe the data submission/sharing timelines](https://sharing.nih.gov/genomic-data-sharing-policy/institutional-certifications/completing-an-institutional-certification-form).
+    - [Provide your Institutional Certification by Just In Time](https://grants.nih.gov/policy-and-compliance/policy-topics/sharing-policies/gds/completing-institutional-certification-form).
+    - [Submit your data to NIH-supported repositories](https://grants.nih.gov/policy-and-compliance/policy-topics/sharing-policies/gds/where-to-submit).
+    - [Observe the data submission/sharing timelines](https://grants.nih.gov/policy-and-compliance/policy-topics/sharing-policies/gds/data-submission-and-release-expectations).
 
 *You should consider protecting (i.e., de-identifying) participant information even if the genetic data are not required to be deposited into NIH/NCI repositories.
 

--- a/pages/Guidance/nci-datasharing-guidance.md
+++ b/pages/Guidance/nci-datasharing-guidance.md
@@ -8,13 +8,13 @@ date: 2025-05-30
 
 If you're generating, collecting, leveraging, or managing NCI-funded research data, you'll need to stay up to date on the latest data sharing requirements.
 
-NCI established the [Office of Data Sharing](https://datascience.cancer.gov/about/organization/office-data-sharing-ods) (ODS) to help you navigate these requirements. This team is your primary source for information on the policies and processes for sharing and using research data.
+NCI established the [Office of Data Sharing](/post/About/About-ODS) (ODS) to help you navigate these requirements. This team is your primary source for information on the policies and processes for sharing and using research data.
 
 In short, when you have a question about how and when to share your NCI-funded research, ODS is here to help you. ([contact ODS](mailto:NCIOfficeofDataSharing@mail.nih.gov)).
 
 **What is NCI's Overall Data Sharing Process?**
 
-NCI's data sharing approach starts and ends with the patient in mind. So, what does this approach look like in its entirety? In this video, ODS Director [Dr. Jaime Guidry Auvil](https://datascience.cancer.gov/content/jaime-m-guidry-auvil-phd) will introduce all the stages of the data sharing lifecycle and share how she and ODS can help you navigate the various steps.
+NCI's data sharing approach starts and ends with the patient in mind. So, what does this approach look like in its entirety? In this video, ODS Director Dr. Jaime Guidry Auvil will introduce all the stages of the data sharing lifecycle and share how she and ODS can help you navigate the various steps.
 
 <iframe
   height=458
@@ -41,11 +41,11 @@ As mentioned in the video, ODS supports data sharing in three main ways. They:
 
 ## Which Sharing Policies Apply to NCI-Funded Research?
 
-Here's a sampling of data policies applicable to NCI-funded research. For additional policies on NIH data sharing, visit [NIH's Scientific Data Sharing website](https://sharing.nih.gov/other-sharing-policies).
+Here's a sampling of data policies applicable to NCI-funded research. For additional policies on NIH data sharing, visit [NIH's Grants Policy website](https://grants.nih.gov/policy-and-compliance/policy-topics/sharing-policies).
 
 ### NIH Data Management and Sharing (DMS) Policy
 
-- **Full Details**: [sharing.nih.gov](https://sharing.nih.gov/data-management-and-sharing-policy/about-data-management-and-sharing-policies/data-management-and-sharing-policy-overview#after)
+- **Full Details**: [grants.nih.gov](https://grants.nih.gov/policy-and-compliance/policy-topics/sharing-policies/dms)
 - **Effective**: January 25, 2023
 - **Applicability**: New applications (Type 1) & competitive renewals (Type 2)
 Competitive revisions (Type 3) & administrative supplements are not subject to the policy
@@ -53,11 +53,11 @@ Competitive revisions (Type 3) & administrative supplements are not subject to t
 - **Expectations**: Prospectively plan how to preserve & share scientific data
 - **Sharing Timelines**: Share scientific data as soon as possible, but not later than the time of associated publication or end of performance period
 - **Data Location(s)**: Repository appropriate for the data generated from the research project, or as in NOFO
-- [DMS Policy FAQs](https://sharing.nih.gov/faqs#/data-management-and-sharing-policy.htm)
+- [DMS Policy FAQs](https://grants.nih.gov/faqs#/data-management-and-sharing-policy.htm)
 
 ### NIH Genomic Data Sharing (GDS) Policy
 
-- **Full Details**: [sharing.nih.gov](https://sharing.nih.gov/genomic-data-sharing-policy/about-genomic-data-sharing)
+- **Full Details**: [grants.nih.gov](https://grants.nih.gov/policy-and-compliance/policy-topics/sharing-policies/gds)
 - **Effective**: January 25, 2015
 - **Applicability**: New applications that generate large-scale genomic data & smaller-scale studies (of programmatic priority, or rare diseases)
   Thresholds & assay types clearly defined for meeting GDS
@@ -65,7 +65,7 @@ Competitive revisions (Type 3) & administrative supplements are not subject to t
 - **Sharing Timelines**: Release lower-level primary data (L2/L3) by 9 months after data generation/QC
   Release summary analyses at publication or end of the project period
 - **Data Location(s)**: NIH-designated data repositories
-- [GDS Policy FAQs](https://sharing.nih.gov/faqs#/genomic-data-sharing-policy.htm)
+- [GDS Policy FAQs](https://grants.nih.gov/faqs#/genomic-data-sharing-policy.htm)
 
 ### Cancer Moonshot<sup>SM</sup> Public Access and Data Sharing (PADS) Policy
 
@@ -74,7 +74,7 @@ Competitive revisions (Type 3) & administrative supplements are not subject to t
 - **Applicability**: Cancer Moonshot research project NOFOs, contracts, and intramural projects generating Publications and Underlying Primary Data
 - **Expectations**: Submit "Public Access and Data Sharing Plans" that describe proposed process for making publications and the underlying primary data immediately and broadly available to the public.
 - **Sharing Timelines**: Immediately and broadly available
-- **Data Location(s)**: an appropriate data repository such as the [Genomic Data Commons](https://gdc.cancer.gov/), [dbGaP](https://www.ncbi.nlm.nih.gov/gap/), [TCIA](http://www.cancerimagingarchive.net/), or a [non-NIH repository](https://sharing.nih.gov/data-management-and-sharing-policy/sharing-scientific-data/repositories-for-sharing-scientific-data) that conforms with the principles articulated in this Policy
+- **Data Location(s)**: an appropriate data repository such as the [Genomic Data Commons](https://gdc.cancer.gov/), [dbGaP](https://www.ncbi.nlm.nih.gov/gap/), [TCIA](http://www.cancerimagingarchive.net/), or a [non-NIH repository](https://grants.nih.gov/policy-and-compliance/policy-topics/sharing-policies/accessing-data/scientific) that conforms with the principles articulated in this Policy
 
 ### Dissemination of NIH-Funded Clinical Trial Information Policy
 
@@ -100,9 +100,9 @@ Competitive revisions (Type 3) & administrative supplements are not subject to t
 
 ### Understanding Policies
 
-- [Policy Decision Tool](https://sharing.nih.gov/other-sharing-policies/which-policies-apply-to-my-research): Use this web application to see which NIH policies might apply to your research.
+- [Policy Decision Tool](https://grants.nih.gov/policy-and-compliance/policy-topics/sharing-policies/which-policies-apply-to-my-research): Use this web application to see which NIH policies might apply to your research.
 - [Toolkit for DMS Policy](https://www.nnlm.gov/guides/nnlm-toolkit-nih-data-management-and-sharing-policy): Learn more about the DMS policy by visiting the National Library of Medicine.
-- [Decision Tree for GDS and 2023 DMS Policy Harmonization](https://datascience.cancer.gov/data-sharing/data-management-genomic-sharing-policy-harmonization-policy-decision-tree): Answer three questions to see if your research must apply the GDS Policy, 2023 DMS Policy, or both.
+- [Decision Tree for GDS and 2023 DMS Policy Harmonization](/post/Guidance/genomic-data-sharing): Answer three questions to see if your research must apply the GDS Policy, 2023 DMS Policy, or both.
 - [OER/OSP Guidance on Informed Consent for Secondary Research with Data and Biospecimens](https://osp.od.nih.gov/wp-content/uploads/Informed-Consent-Resource-for-Secondary-Research-with-Data-and-Biospecimens.pdf): Use this templated language to write your informed consent documents and maximize data sharing.
 
 ### Projects

--- a/pages/Guidance/writing-DMSP.md
+++ b/pages/Guidance/writing-DMSP.md
@@ -8,11 +8,11 @@ date: 2025-05-30
 
 If you're a researcher seeking NIH funding, you're likely aware that you need to prepare and submit a detailed Data Management and Sharing (DMS) Plan along with your funding application. In this article, we'll highlight key components of this DMS Plan.
 
-Please note that this isn't an exhaustive description of what's needed for NIH. For detailed instructions, we encourage you to refer to the [application guide](https://sharing.nih.gov/data-management-and-sharing-policy/planning-and-budgeting-for-data-management-and-sharing/writing-a-data-management-and-sharing-plan#after), as well as requirements outlined in your funding opportunity.
+Please note that this isn't an exhaustive description of what's needed for NIH. For detailed instructions, we encourage you to refer to the [application guide](https://grants.nih.gov/policy-and-compliance/policy-topics/sharing-policies/dms/writing-dms-plan), as well as requirements outlined in your funding opportunity.
 
 ## What is a DMS Plan?
 
-The DMS Plan reflects NIH's 2023 DMS Policy. With this policy, NIH is looking to significantly expand data sharing, ensuring that the research community has timely access to NIH-funded scientific data. (For general information on NIH policy expectations for sharing research data, visit the [Scientific Data Sharing](https://sharing.nih.gov/data-management-and-sharing-policy) website.)
+The DMS Plan reflects NIH's 2023 DMS Policy. With this policy, NIH is looking to significantly expand data sharing, ensuring that the research community has timely access to NIH-funded scientific data. (For general information on NIH policy expectations for sharing research data, visit the [Scientific Data Sharing](https://grants.nih.gov/policy-and-compliance/policy-topics/sharing-policies/dms) website.)
 
 ## When is a DMS Plan Required?
 
@@ -27,7 +27,7 @@ The 2023 DMS Policy defines scientific data as recorded, factual information tha
 
 ### Other Considerations
 
-In addition to the 2023 DMS Policy, there may be other policies that apply to your work. For example, if you're conducting large-scale genomic research, your DMS Plan should include elements described in the NIH [Genomics Data Sharing (GDS) Policy](https://sharing.nih.gov/genomic-data-sharing-policy/about-genomic-data-sharing) (e.g., type of genomic assay, number of subjects and timeline for submission to an NIH-designated repository, etc.). NIH's GDS Policy applies to all NIH-funded research (e.g., grants, contracts, intramural research, regardless of funding level) that generates or reuses genomic data from large-scale human or non-human research.
+In addition to the 2023 DMS Policy, there may be other policies that apply to your work. For example, if you're conducting large-scale genomic research, your DMS Plan should include elements described in the NIH [Genomics Data Sharing (GDS) Policy](https://grants.nih.gov/policy-and-compliance/policy-topics/sharing-policies/gds/overview) (e.g., type of genomic assay, number of subjects and timeline for submission to an NIH-designated repository, etc.). NIH's GDS Policy applies to all NIH-funded research (e.g., grants, contracts, intramural research, regardless of funding level) that generates or reuses genomic data from large-scale human or non-human research.
 
 ## Why Do I Need a DMS Plan?
 
@@ -85,7 +85,7 @@ Describe the metadata and standards you'll use to improve your data's operabilit
 Describe how and when you'll be archiving your scientific data and metadata. Be sure to include:
 
 - the names of the repository(ies) where you will preserve and share your data.
-  - [Learn more about selecting a repository](https://sharing.nih.gov/data-management-and-sharing-policy/sharing-scientific-data/selecting-a-data-repository).
+  - [Learn more about selecting a repository](https://grants.nih.gov/policy-and-compliance/policy-topics/sharing-policies/dms/selecting-a-data-repository).
 - a timeline for when the data will be available to other researchers.
   - You should share your results as soon as possible (i.e., by the time you publish your first results or by the end of the performance period, *whichever comes first*.)
 - an estimate for how long you will preserve and share your data.
@@ -98,12 +98,12 @@ Describe how and when you'll be archiving your scientific data and metadata. Be 
 - *When setting realistic timelines for preserving and sharing your data, be sure to consider tasks that could alter your data sharing timeline (e.g., repository policies, award record retention requirements, journal publication schedules). You'll need to indicate if any of your data subsets have different timelines. If you're completing a GDS and DMS Plan, be sure the timelines align and meet policy expectations.*
 - *Make certain your data are FAIR (i.e., findable, accessible, interoperable, and reusable) and include any necessary digital object identifiers, accession numbers, and hyperlinks to data sets.*
 - *You may deposit different types of data from the same participants into several repositories, as long as the secondary users are aware of where to find and access those data sets.*
-- *Your repository(ies) may include [Generalist Repositories](https://sharing.nih.gov/data-management-and-sharing-policy/sharing-scientific-data/generalist-repositories), unless otherwise specified by the funding opportunity announcements or NCI-specific policy(ies).*
-- *If you plan on depositing data into one of [NCI's Cancer Research Data Commons (CRDC) repositories](https://datascience.cancer.gov/data-commons/repositories), such as [GDC](https://gdc.cancer.gov/), [PDC](https://pdc.cancer.gov/pdc/), [CDS](https://datacommons.cancer.gov/repository/cancer-data-service), [ICDC](https://datacommons.cancer.gov/repository/integrated-canine-data-commons), be aware that you'll need prior approval.*
+- *Your repository(ies) may include [Generalist Repositories](https://grants.nih.gov/policy-and-compliance/policy-topics/sharing-policies/accessing-data/scientific#generalist-repositories), unless otherwise specified by the funding opportunity announcements or NCI-specific policy(ies).*
+- *If you plan on depositing data into one of [NCI's Cancer Research Data Commons (CRDC) repositories](https://datascience.cancer.gov/data-commons/repositories), such as [GDC](https://gdc.cancer.gov/), [PDC](https://pdc.cancer.gov/pdc/), [GC](https://datacommons.cancer.gov/repository/general-commons), [ICDC](https://datacommons.cancer.gov/repository/integrated-canine-data-commons), be aware that you'll need prior approval.*
 
 #### Element 5: Explain How Data Users Will Access and Reuse Your Data
 
-Describe how others can access and reuse your scientific data for each data type. [Find examples of justifiable reasons for limiting the sharing of data](https://sharing.nih.gov/faqs#/data-management-and-sharing-policy.htm?anchor=56549). Be sure to include:
+Describe how others can access and reuse your scientific data for each data type. [Find examples of justifiable reasons for limiting the sharing of data](https://grants.nih.gov/faqs#/data-management-and-sharing-policy.htm?anchor=56549). Be sure to include:
 
 - a thorough description of how others can access your data.
   - Will the data be open access or available with permission? How will you manage that access (e.g., through prior registration with the repository).
@@ -143,13 +143,13 @@ Now that you have a sense of what your plan should contain, use the following re
 
 ### Resources and Tools
 
-- [DMS Plan](https://sharing.nih.gov/data-management-and-sharing-policy/planning-and-budgeting-for-data-management-and-sharing/writing-a-data-management-and-sharing-plan): Learn what NIH expects in a DMS Plan and get additional direction on developing a plan.
-- Repositories: Visit our [NCI Data Catalog](https://datascience.cancer.gov/resources/nci-data-catalog) for a list of data collections produced by major NCI initiatives and other widely used data sets. Also, [visit the NIH Scientific Data Sharing website](https://sharing.nih.gov/data-management-and-sharing-policy/sharing-scientific-data/repositories-for-sharing-scientific-data) for a full list of NIH-supported repositories.
+- [DMS Plan](https://grants.nih.gov/policy-and-compliance/policy-topics/sharing-policies/dms/writing-dms-plan): Learn what NIH expects in a DMS Plan and get additional direction on developing a plan.
+- Repositories: Visit our [NCI Data Catalog](https://datascience.cancer.gov/resources/nci-data-catalog) for a list of data collections produced by major NCI initiatives and other widely used data sets. Also, [visit the NIH Scientific Data Sharing website](https://grants.nih.gov/policy-and-compliance/policy-topics/sharing-policies/accessing-data/scientific) for a full list of NIH-supported repositories.
 - [Training Modules](https://www.nigms.nih.gov/training/pages/clearinghouse-for-training-modules-to-enhance-data-reproducibility.aspx): Watch these training modules on how to enhance data reproducibility.
-- [Writing Applicable Activity Codes](https://sharing.nih.gov/sites/default/files/flmngr/List-of-Activity-Codes-Applicable-to-DMS-Policy.pdf): Review this list of activity codes to see if you need to write a DMS Plan for your research.
+- [Writing Applicable Activity Codes](https://grants.nih.gov/sites/default/files/flmngr/List-of-Activity-Codes-Applicable-to-DMS-Policy.pdf): Review this list of activity codes to see if you need to write a DMS Plan for your research.
 - [DMPTool](https://www.nnlm.gov/guides/data-glossary/data-management-planning-tool-dmptool): Sign up to use this free software, which will walk you through creating DMS plans based on NIH templates.
 - [NIH Federal Demonstration Partnership](https://thefdp.org/demonstrations-resources/nih-data-management-sharing-pilot/): Write your DMS plan using one, or preferably both, templates offered by the Federal Demonstration Partnership. After you use these pilot templates, be sure you give feedback! This will help NIH create an NIH-wide plan template in the future.
-- [NIH-Supported Scientific Data Repositories](https://sharing.nih.gov/data-management-and-sharing-policy/sharing-scientific-data/repositories-for-sharing-scientific-data): For examples, explore this list of repositories which house various types of data.
+- [NIH-Supported Scientific Data Repositories](https://grants.nih.gov/policy-and-compliance/policy-topics/sharing-policies/accessing-data/scientific): For examples, explore this list of repositories which house various types of data.
 
 ### Tools to Help Standardize Data
 

--- a/pages/Process/Access-data.md
+++ b/pages/Process/Access-data.md
@@ -22,21 +22,21 @@ Some repositories allow access to their data only if users are registered with t
 
 In addition to open-access data sets, NCI facilitates requests to controlled-access data for NCI intramural staff scientists and extramural investigators. To use controlled data, you must obtain prior authorization through a Data Access Committee. NCI’s data access processes ensure that requests comply with NIH’s data sharing policies, and the data are used in ways that adhere to the consent given by research participants in their original studies.
 
-***All users are expected to use the data responsibly.** [See Using Genomic Data Responsibly Under the NIH Genomic Data Sharing Policy](https://sharing.nih.gov/accessing-data/accessing-genomic-data/using-genomic-data-responsibly)
+***All users are expected to use the data responsibly.** [See Using Genomic Data Responsibly Under the NIH Genomic Data Sharing Policy](https://grants.nih.gov/policy-and-compliance/policy-topics/sharing-policies/accessing-data/using-genomic-data)
 
 ## Where to Find Scientific Data
 
 | | |
 |---|---|
-| ![Data cloud icon](https://raw.githubusercontent.com/CBIIT/ccdi-ods-content/main/pages/images/icons/cloud_upload_icon.png) | [NIH-supported Repositories for Accessing Scientific Data](https://sharing.nih.gov/accessing-data/accessing-scientific-data) |
+| ![Data cloud icon](https://raw.githubusercontent.com/CBIIT/ccdi-ods-content/main/pages/images/icons/cloud_upload_icon.png) | [NIH-supported Repositories for Accessing Scientific Data](https://grants.nih.gov/policy-and-compliance/policy-topics/sharing-policies/accessing-data/scientific) |
 | ![Folder icon](https://raw.githubusercontent.com/CBIIT/ccdi-ods-content/main/pages/images/icons/folder_icon.png) | [Index of NCI Studies](https://studycatalog.cancer.gov) |
 
 ## Where to Find Genomic Data
 
 | | |
 |---|---|
-| ![Data cloud icon](https://raw.githubusercontent.com/CBIIT/ccdi-ods-content/main/pages/images/icons/cloud_upload_icon.png) | [Accessing Genomic Data from NIH Repositories](https://sharing.nih.gov/accessing-data/accessing-genomic-data/accessing-genomic-data-from-nih-repositories) |
-| ![Folder icon](https://raw.githubusercontent.com/CBIIT/ccdi-ods-content/main/pages/images/icons/folder_icon.png) | [How to Request and Access Datasets from dbGaP](https://sharing.nih.gov/accessing-data/accessing-genomic-data/how-to-request-and-access-datasets-from-dbgap) |
+| ![Data cloud icon](https://raw.githubusercontent.com/CBIIT/ccdi-ods-content/main/pages/images/icons/cloud_upload_icon.png) | [Accessing Genomic Data from NIH Repositories](https://grants.nih.gov/policy-and-compliance/policy-topics/sharing-policies/accessing-data/genomic-data) |
+| ![Folder icon](https://raw.githubusercontent.com/CBIIT/ccdi-ods-content/main/pages/images/icons/folder_icon.png) | [How to Request and Access Datasets from dbGaP](https://grants.nih.gov/policy-and-compliance/policy-topics/sharing-policies/accessing-data/dbgap) |
 
 &nbsp;  
 

--- a/pages/Process/Submit-Data.md
+++ b/pages/Process/Submit-Data.md
@@ -14,7 +14,7 @@ Data sharing allows data generated from one research study to be used to answe
 
 | | |
 |---|---|
-| ![Data cloud icon](https://raw.githubusercontent.com/CBIIT/ccdi-ods-content/main/pages/images/icons/cloud_upload_icon.png) | [NIH-supported Repositories for Sharing Scientific Data](https://sharing.nih.gov/data-management-and-sharing-policy/sharing-scientific-data/repositories-for-sharing-scientific-data) |
+| ![Data cloud icon](https://raw.githubusercontent.com/CBIIT/ccdi-ods-content/main/pages/images/icons/cloud_upload_icon.png) | [NIH-supported Repositories for Sharing Scientific Data](https://grants.nih.gov/policy-and-compliance/policy-topics/sharing-policies/accessing-data/scientific) |
 | ![Folder icon](https://raw.githubusercontent.com/CBIIT/ccdi-ods-content/main/pages/images/icons/folder_icon.png) | [NCI Cancer Research Data Commons](https://datacommons.cancer.gov/explore/data-commons) (CRDC)* |
 
 ***Prior approval is required for submission to the CRDC. See [https://datacommons.cancer.gov/submit](https://datacommons.cancer.gov/submit) for more information.**
@@ -29,7 +29,7 @@ Submitting genomic research data enables translating research findings into know
 Researchers submitting genomic data should refer to the data practices, file formats, resources, and processes:
 
 - [Sharing Data: The Basics](https://datascience.cancer.gov/training/learn-data-science/share-data-basics)
-- [Intramural and Extramural NCI Investigators](https://sharing.nih.gov/genomic-data-sharing-policy/submitting-genomic-data/how-to-register-and-submit-a-study-in-dbgap)
+- [Intramural and Extramural NCI Investigators](https://grants.nih.gov/policy-and-compliance/policy-topics/sharing-policies/gds/register-submit-study-dbgap)
 - [Non-NCI Funded Studies](/post/Process/non-NIH-funded-study-submission)
 
 &nbsp;  

--- a/pages/Process/non-NIH-funded-study-submission.md
+++ b/pages/Process/non-NIH-funded-study-submission.md
@@ -6,13 +6,13 @@ date: 2025-05-30
 
 # Request to Submit Cancer Genomic Data from a Non-NIH-Funded Study
 
-If your study is not funded by NCI, you may still be able to share your genomic and other -omics study data through an NIH repository. An NCI subcommittee will review each application on a case-by-case basis considering the scientific value of the data, its usage of NIH resources, and the data use limitations (DULs). NCI will only accept data that complies with NIH's [Genomic Data Sharing (GDS) Policy](https://datascience.cancer.gov/data-sharing/genomic-data-sharing/about-the-genomic-data-sharing-policy). Though this process will register your study through the database of Genotypes and Phenotypes (dbGaP), NCI may deposit your data into [any NIH repository](https://www.nlm.nih.gov/NIHbmic/nih_data_sharing_repositories.html).
+If your study is not funded by NCI, you may still be able to share your genomic and other -omics study data through an NIH repository. An NCI subcommittee will review each application on a case-by-case basis considering the scientific value of the data, its usage of NIH resources, and the data use limitations (DULs). NCI will only accept data that complies with NIH's [Genomic Data Sharing (GDS) Policy](https://grants.nih.gov/policy-and-compliance/policy-topics/sharing-policies/gds/overview). Though this process will register your study through the database of Genotypes and Phenotypes (dbGaP), NCI may deposit your data into [any NIH repository](https://grants.nih.gov/policy-and-compliance/policy-topics/sharing-policies/accessing-data/scientific).
 
 To apply to share your data set through NCI, follow the steps below:
 
 ## Step 1: Complete Documentation
 
-You must complete both the [Institutional Certification](https://sharing.nih.gov/genomic-data-sharing-policy/institutional-certifications/completing-an-institutional-certification-form) (IC) form and the [Online Non-NCI-Funded Study](https://forms.office.com/Pages/ResponsePage.aspx?id=eHW3FHOX1UKFByUcotwrBjcbADvs4RxIobADe4cxh_ZURUxNNUUzU0NTWDdGR0dLWjdPSFg4SVRDUi4u) Information forms.
+You must complete both the [Institutional Certification](https://grants.nih.gov/policy-and-compliance/policy-topics/sharing-policies/gds/completing-institutional-certification-form) (IC) form and the [Online Non-NCI-Funded Study](https://forms.office.com/Pages/ResponsePage.aspx?id=eHW3FHOX1UKFByUcotwrBjcbADvs4RxIobADe4cxh_ZURUxNNUUzU0NTWDdGR0dLWjdPSFg4SVRDUi4u) Information forms.
 
 ### **Tips for Completing the IC Form**
 
@@ -30,7 +30,7 @@ We've outlined a few points to clarify common questions from previous data submi
 
 #### **Page 3: Data Use Limitations**
 
-- Select appropriate DULS and/or DUL modifiers based on the language of participant's consent form and your IRB's advisement. You can learn more about what is imposed by these restrictions by reading the [Standard Data Use Limitations](https://sharing.nih.gov/genomic-data-sharing-policy/institutional-certifications/completing-an-institutional-certification-form#step-5) table created by NIH's Office of Science Policy.
+- Select appropriate DULS and/or DUL modifiers based on the language of participant's consent form and your IRB's advisement. You can learn more about what is imposed by these restrictions by reading the [Standard Data Use Limitations](https://grants.nih.gov/policy-and-compliance/policy-topics/sharing-policies/gds/completing-institutional-certification-form#step-5) table created by NIH's Office of Science Policy.
 
 > **Please note that General Research Use without any further restricting modifiers allows the maximal benefit of research funded with public dollars and is preferred whenever possible and consistent with informed consent. If disease-specific data use or data-use modifiers are required, please [contact the NCI Office of Data Sharing](mailto:NCIOfficeofDataSharing@mail.nih.gov) for further guidance.**
 
@@ -74,7 +74,7 @@ If you encounter difficulties submitting data to dbGaP, please contact their hel
 |------------|---------|
 | Database of Genotypes and Phenotypes (dbGaP) | [dbGaP Contact Form](https://dbgap.ncbi.nlm.nih.gov/aa/wga.cgi?page=email&from=login) |
 | Sequence Read Archive (SRA) | [SRA Help Desk](mailto:sra@ncbi.nlm.nih.gov) |
-| Other National Center for Biotechnology Information (NCBI) [Data Repositories](https://support.nlm.nih.gov/support/create-case) | [National Library of Medicine Help Desk](https://support.nlm.nih.gov/support/create-case) |
+| Other National Center for Biotechnology Information (NCBI) | [National Library of Medicine Help Desk](https://support.nlm.nih.gov/support/create-case) |
 
 For additional questions about data sharing, please contact [NCI's Office of Data Sharing](mailto:NCIOfficeofDataSharing@mail.nih.gov).
 


### PR DESCRIPTION
Migrate all links from deprecated sharing.nih.gov to pages on grants.nih.gov. 

Where possible, also migrate links away from the soon-to-be-deprecated datascience.cancer.gov/data-sharing.