### PR TITLE
DATASHARE-70: Update CPTAC and APOLLO links

### DIFF
--- a/pages/Data/cancer-data-resources.md
+++ b/pages/Data/cancer-data-resources.md
@@ -32,9 +32,9 @@ The **Index of NCI Studies (INS)** compiles and shares publicly available inform
 
 ## APOLLO
 
-The **Applied Proteogenomics OrganizationaL Learning and Outcomes (APOLLO) network (APOLLO)** is a multi-institutional network that integrates proteomics and genomics data to improve cancer patient outcomes. APOLLO connects proteomic research with clinical practice to advance precision oncology and personalized treatment approaches.
+The **Applied Proteogenomics OrganizationaL Learning and Outcomes (APOLLO) network** is a multi-institutional network that integrates proteomics and genomics data to improve cancer patient outcomes. APOLLO connects proteomic research with clinical practice to advance precision oncology and personalized treatment approaches.
 
-[APOLLO Website](https://proteomics.cancer.gov/programs/apollo-network) | [Data Access](https://proteomics.cancer.gov/data-portal)
+[APOLLO Website](https://dctd.cancer.gov/research/networks/apollo) | [Data Access](https://pdc.cancer.gov/pdc/)
 
 ## ARTNet
 

--- a/pages/Data/cancer-data-resources.md
+++ b/pages/Data/cancer-data-resources.md
@@ -112,7 +112,7 @@ The **Cancer Prevention Clinical Trials Network (CP-CTNet)** is a clinical trial
 
 The **Clinical Proteomic Tumor Analysis Consortium (CPTAC)** is a multi-institutional consortium that conducts comprehensive proteomic analysis of cancer samples from TCGA and other sources. CPTAC generates high-quality proteomic data to complement genomic information for cancer research.
 
-[CPTAC Website](https://proteomics.cancer.gov/programs/cptac) | [Data Access](https://gdc.cancer.gov/about-gdc/contributed-genomic-data-cancer-research/clinical-proteomic-tumor-analysis-consortium-cptac)
+[CPTAC Website](https://dctd.cancer.gov/research/networks/cptac) | [Data Access](https://pdc.cancer.gov/pdc/)
 
 ## CSBC
 


### PR DESCRIPTION
Update links and description for APOLLO and links for CPTAC on the Data Sharing Hub Resources and Tools page. 

New links reflect the proper destinations after the launch of the new DCTD site. 